### PR TITLE
Подключение стилей: normalize, reset, mixins, variables

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -3,4 +3,4 @@ pre-commit:
   commands:
     lint:
       glob: '*.{ts,tsx}'
-      run: yarn eslint {staged_files} && yarn format
+      run: yarn eslint {staged_files} && yarn format && git add -A 

--- a/packages/client/src/main.scss
+++ b/packages/client/src/main.scss
@@ -1,0 +1,1 @@
+@import './styles/main.scss';

--- a/packages/client/src/styles/main.scss
+++ b/packages/client/src/styles/main.scss
@@ -1,0 +1,4 @@
+@import 'variables.scss';
+@import 'mixins.scss';
+@import 'normalize.scss';
+@import 'reset.scss';

--- a/packages/client/src/styles/mixins.scss
+++ b/packages/client/src/styles/mixins.scss
@@ -1,0 +1,10 @@
+@mixin f-center {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+@mixin f-column {
+  display: flex;
+  flex-direction: column;
+}

--- a/packages/client/src/styles/normalize.scss
+++ b/packages/client/src/styles/normalize.scss
@@ -1,0 +1,130 @@
+pre {
+  font-family: monospace, monospace;
+  font-size: 1em;
+}
+a {
+  background-color: transparent;
+  text-decoration: underline;
+  cursor: pointer;
+}
+abbr[title] {
+  border-bottom: none;
+  text-decoration: underline;
+  text-decoration: underline dotted;
+}
+b,
+strong {
+  font-weight: bolder;
+}
+code,
+kbd,
+samp {
+  font-family: monospace, monospace;
+  font-size: 1em;
+}
+small {
+  font-size: 80%;
+}
+sub,
+sup {
+  font-size: 75%;
+  line-height: 0;
+  position: relative;
+  vertical-align: baseline;
+}
+sub {
+  bottom: -0.25em;
+}
+sup {
+  top: -0.5em;
+}
+button,
+input,
+optgroup,
+select,
+textarea {
+  font-family: inherit;
+  font-size: 100%;
+  line-height: 1.15;
+  margin: 0;
+}
+button,
+input {
+  overflow: visible;
+}
+button,
+select {
+  text-transform: none;
+}
+button,
+[type='button'],
+[type='reset'],
+[type='submit'] {
+  -webkit-appearance: button;
+  appearance: button;
+  cursor: pointer;
+  border: none;
+}
+button::-moz-focus-inner,
+[type='button']::-moz-focus-inner,
+[type='reset']::-moz-focus-inner,
+[type='submit']::-moz-focus-inner {
+  border-style: none;
+  padding: 0;
+}
+button:-moz-focusring,
+[type='button']:-moz-focusring,
+[type='reset']:-moz-focusring,
+[type='submit']:-moz-focusring {
+  outline: 1px dotted ButtonText;
+}
+fieldset {
+  padding: 0.35em 0.75em 0.625em;
+}
+legend {
+  box-sizing: border-box;
+  color: inherit;
+  display: table;
+  max-width: 100%;
+  padding: 0;
+  white-space: normal;
+}
+progress {
+  vertical-align: baseline;
+}
+textarea {
+  overflow: auto;
+}
+[type='checkbox'],
+[type='radio'] {
+  box-sizing: border-box;
+  padding: 0;
+}
+[type='number']::-webkit-inner-spin-button,
+[type='number']::-webkit-outer-spin-button {
+  height: auto;
+}
+[type='search'] {
+  -webkit-appearance: textfield;
+  appearance: textfield;
+  outline-offset: -2px;
+}
+[type='search']::-webkit-search-decoration {
+  -webkit-appearance: none;
+}
+::-webkit-file-upload-button {
+  -webkit-appearance: button;
+  font: inherit;
+}
+details {
+  display: block;
+}
+summary {
+  display: list-item;
+}
+template {
+  display: none;
+}
+[hidden] {
+  display: none;
+}

--- a/packages/client/src/styles/reset.scss
+++ b/packages/client/src/styles/reset.scss
@@ -1,0 +1,49 @@
+// тут RESET и NORMOLIZE, трогаем только при необходимости
+
+*,
+*:after,
+*:before {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+  line-height: 100%;
+  vertical-align: middle;
+  text-rendering: optimizeLegibility;
+  font-family: Rubik, sans-serif;
+}
+html {
+  font-size: 10px;
+  line-height: 1.15;
+  scroll-behavior: smooth;
+  -webkit-text-size-adjust: 100%;
+}
+body {
+  margin: 0;
+  font-size: 10px;
+}
+main {
+  display: block;
+}
+hr {
+  box-sizing: content-box;
+  height: 0;
+  overflow: visible;
+}
+ol,
+ul {
+  list-style: none;
+}
+li {
+  list-style: none;
+  cursor: pointer;
+}
+img,
+svg {
+  width: 100%;
+  border: 0;
+  border-style: none;
+}
+table {
+  border-collapse: collapse;
+  border-spacing: 0;
+}

--- a/packages/client/src/styles/variables.scss
+++ b/packages/client/src/styles/variables.scss
@@ -1,0 +1,2 @@
+$base-color: #c6538c;
+$border-dark: rgba($base-color, 0.88);


### PR DESCRIPTION
### Подключение стилей: normalize, reset, mixins, variables
Добавил файлы в папку styles: main.scss, reset.scss, mixins.scss, variables.scss. Сделал импорт в main.scss. Обратите внимание что в reset.scss, в селекторе body и html, font-size установлен  в 10px, для того что бы было удобно рассчитывать сколько px в одном rem. Если такая практика кому-то не удобна, то прошу прокомментировать данный пункт. Остальное все стандартно.
